### PR TITLE
Ajout d'une option pour affiner la compilation

### DIFF
--- a/songbook
+++ b/songbook
@@ -21,10 +21,15 @@ from songbook_core import errors
 class ParseStepsAction(argparse.Action):
     """Argparse action to split a string into a list."""
     def __call__(self, __parser, namespace, values, __option_string=None):
+        if not getattr(namespace, self.dest):
+            setattr(namespace, self.dest, [])
         setattr(
                 namespace,
                 self.dest,
-                [value.strip() for value in values[0].split(',')],
+                (
+                    getattr(namespace, self.dest)
+                    + [value.strip() for value in values[0].split(',')]
+                ),
                 )
 
 def argument_parser(args):
@@ -52,9 +57,13 @@ def argument_parser(args):
                     "tex" produce .tex file from templates;
                     "pdf" compile .tex file;
                     "sbx" compile index files;
-                    "clean" remove temporary files.
+                    "clean" remove temporary files;
+                    any string beginning with '%%' (in this case, it will be run
+                    in a shell). Several steps (excepted the custom shell
+                    command) can be combinend in one --steps argument, as a
+                    comma separated string.
             """.format(steps=','.join(DEFAULT_STEPS))),
-            default=DEFAULT_STEPS,
+            default=None,
             )
 
     options = parser.parse_args(args)

--- a/songbook_core/build.py
+++ b/songbook_core/build.py
@@ -208,6 +208,12 @@ def buildsongbook(
         elif step == 'clean':
             # Cleaning
             clean(basename)
+        elif step.startswith("%"):
+            # Shell command
+            command = step[1:]
+            exit_code = subprocess.call(command, shell=True)
+            if exit_code:
+                raise errors.StepCommandError(command, exit_code)
         else:
             # Unknown step name
             raise errors.UnknownStep(step)

--- a/songbook_core/errors.py
+++ b/songbook_core/errors.py
@@ -18,10 +18,21 @@ class LatexCompilationError(SongbookError):
         self.basename = basename
 
     def __str__(self):
-        return (
-                """Error while pdfLaTeX compilation of "{basename}.tex"
-                (see {basename}.log for more information)."""
+        return ("""Error while pdfLaTeX compilation of "{basename}.tex" """
+                """(see {basename}.log for more information)."""
                 ).format(basename=self.basename)
+
+class StepCommandError(SongbookError):
+    """Error during LaTeX compilation."""
+
+    def __init__(self, command, code):
+        super(StepCommandError, self).__init__()
+        self.command = command
+        self.code = code
+
+    def __str__(self):
+        return ("""Error while running custom command "{command}": got return"""
+                " code {code}.").format(command=self.command, code=self.code)
 
 class CleaningError(SongbookError):
     """Error during cleaning of LaTeX auxiliary files."""


### PR DESCRIPTION
La branche suivante ajoute une option définir la liste des étapes dans la compilation. Le défaut est `tex,pdf,sbx,pdf,clean` (compiler le tex, compiler le pdf, compiler les index, compiler à nouveau le pdf, nettoyer les fichiers temporaires).

L'idée est que l'utilisateur a maintenant plus de contrôles sur la compilation. Par exemple : 
- si l'utilisateur a une bibliographie, il peut compiler avec la suite de commandes `songbook --steps tex,pdf carnet.sb; bibtex carnet; songbook --steps sbx,pdf,clean` ;
- si l'utilisateur veut compiler deux fois de suite pour que sa table des matières soit correcte, il peut utiliser `songbook --steps tex,pdf,sbx,pdf,pdf,clean carnet.sb` ;
- si l'utilisateur ne veut pas nettoyer les fichiers temporaires (pour étuidier le .tex par exemple), il utilise `songbook --steps tex,pdf,sbx,pdf carnet.sb` ;
- etc.

Je vous laisse accepter ce pull request s'il vous satisfait.
