### PR TITLE
Inclusion de l'unité dans la taille de la police

### DIFF
--- a/songbook_core/data/templates/default.tex
+++ b/songbook_core/data/templates/default.tex
@@ -21,6 +21,12 @@
 
 (* variables *)
 {
+"classoptions": {"description": {"english": "LaTeX class options", "french": "Options de la classe LaTeX"},
+               "type": "flag",
+               "join": ",",
+               "mandatory": true,
+               "default": {"default":[]}
+            },
 "title": {"description": {"english": "Title", "french": "Titre"},
             "default": {"english": "Guitar songbook", "french": "Recueil de chansons pour guitare"},
             "mandatory":true
@@ -68,6 +74,12 @@
 
 (* extends "songs.tex" *)
 (* set indexes = "titleidx,authidx" *)
+
+(* block documentclass *)
+\documentclass[(* for option in classoptions *)
+            ((option)),
+          (* endfor *)]{article}
+(* endblock *)
 
 
 (* block songbookpreambule *)

--- a/songbook_core/data/templates/layout.tex
+++ b/songbook_core/data/templates/layout.tex
@@ -26,17 +26,8 @@
 %%
 %% Generated using Songbook <http://www.patacrep.com>
 
-(* variables *)
-{
-"mainfontsize": {"description": {"english": "Font Size", "french": "Taille de police"},
-               "type":"font",
-               "default":{"default": "10pt"}
-            }
-}
-(* endvariables *)
-
 (* block documentclass *)
-\documentclass[((mainfontsize))]{article}
+\documentclass{article}
 (* endblock *)
 
 (* block songbookpackages *)


### PR DESCRIPTION
Je trouve ça plus simple si l'unité de la taille de la police n'est pas fournie par défaut. Dans ce cas, si la variable `mainfontsize` n'est pas définie, nous n'obtenons pas une option `pt` seule passée à la classe article, qui fait planter la compilation : on n'a qu'une liste d'options vides.
