### PR TITLE
The template shouldn't add a space artist name

### DIFF
--- a/patacrep/songs/chordpro/data/chordpro/song
+++ b/patacrep/songs/chordpro/data/chordpro/song
@@ -13,7 +13,7 @@
 (* endfor -*)
 
 (*- for author in authors -*)
-  {artist: (( author[1] )) (( author[0] ))}
+  {artist: (( author[1] ))(( author[0] ))}
 (* endfor *)
 
 (*- for key in ['album', 'copyright', 'cov', 'tag'] *)

--- a/patacrep/songs/chordpro/data/latex/song
+++ b/patacrep/songs/chordpro/data/latex/song
@@ -16,7 +16,7 @@
 }[
   by={
       (* for author in authors *)
-        (( author[1] )) (( author[0] ))
+        (( author[1] ))(( author[0] ))
         (*- if not loop.last -*)
         ,
         (* endif *)

--- a/patacrep/songs/chordpro/test/author_names.sgc
+++ b/patacrep/songs/chordpro/test/author_names.sgc
@@ -1,0 +1,6 @@
+{language: english}
+{title: Title}
+{artist: The Beatles}
+{artist: Oasis}
+{artist: The the beatles}
+

--- a/patacrep/songs/chordpro/test/author_names.source
+++ b/patacrep/songs/chordpro/test/author_names.source
@@ -1,0 +1,4 @@
+{title: Title}
+{artist: The Beatles}
+{artist: Oasis}
+{artist: The the beatles}

--- a/patacrep/songs/chordpro/test/author_names.tex
+++ b/patacrep/songs/chordpro/test/author_names.tex
@@ -1,0 +1,12 @@
+\selectlanguage{english}
+
+\beginsong{Title}[
+  by={
+        The Beatles,
+        Oasis,
+        The the beatles  },
+]
+
+
+
+\endsong

--- a/patacrep/songs/chordpro/test/greensleeves.sgc
+++ b/patacrep/songs/chordpro/test/greensleeves.sgc
@@ -3,7 +3,7 @@
 {title: Greensleeves}
 {title: Un autre sous-titre}
 {title: Un sous titre}
-{artist:  Traditionnel}
+{artist: Traditionnel}
 {album: Angleterre}
 {cov: traditionnel}
 

--- a/patacrep/songs/chordpro/test/greensleeves.tex
+++ b/patacrep/songs/chordpro/test/greensleeves.tex
@@ -5,7 +5,7 @@
 Un autre sous-titre\\
 Un sous titre}[
   by={
-         Traditionnel  },
+        Traditionnel  },
   album={Angleterre},
   cov={traditionnel},
 ]

--- a/patacrep/songs/chordpro/test/metadata.sgc
+++ b/patacrep/songs/chordpro/test/metadata.sgc
@@ -6,8 +6,8 @@
 {title: Subtitle3}
 {title: Subtitle4}
 {title: Subtitle5}
-{artist:  Author1}
-{artist:  Author2}
+{artist: Author1}
+{artist: Author2}
 {album: Album}
 {copyright: Copyright}
 {cov: Cover}

--- a/patacrep/songs/chordpro/test/metadata.tex
+++ b/patacrep/songs/chordpro/test/metadata.tex
@@ -7,8 +7,8 @@ Subtitle3\\
 Subtitle4\\
 Subtitle5}[
   by={
-         Author1,
-         Author2  },
+        Author1,
+        Author2  },
   album={Album},
   copyright={Copyright},
   cov={Cover},


### PR DESCRIPTION
J'ai commencé à me plonger dans les tests de patacrep et j'ai cru repérer une petite erreur concernant l'affichage des noms des artistes (un espace de trop).

J'ai mis à jour les tests concerné et j'en ai rajouté pour être confirmer la bonne gestion des noms avec `The` et autres.

J'ai essayé de faire de mon mieux, mais puisque c'est la première fois que je touche aux tests, j'apprécierai d'avoir votre avis :-)