### PR TITLE
Refactor tests

### DIFF
--- a/patacrep/songs/chordpro/test/test_parser.py
+++ b/patacrep/songs/chordpro/test/test_parser.py
@@ -15,6 +15,9 @@ LANGUAGES = {
     'sgc': 'chordpro',
 }
 
+# Set to True if you want to create missing rendered files
+CREATE_MISSING_RENDERED_FILE = False
+
 class TestParsingRendering(unittest.TestCase):
     """Test parsing and rendering"""
 
@@ -39,6 +42,17 @@ class TestParsingRendering(unittest.TestCase):
             for dest in LANGUAGES:
                 destname = "{}.{}".format(base, dest)
                 if not os.path.exists(destname):
+                    if CREATE_MISSING_RENDERED_FILE:
+                        print("Creating " + destname)
+                        with open(destname, 'w', encoding='utf8') as expectfile:
+                            chordproname = "{}.source".format(base)
+                            config['filename'] = chordproname
+                            expectfile.write(
+                                        ChordproSong(None, chordproname, config).render(
+                                            output=chordproname,
+                                            output_format=LANGUAGES[dest],
+                                            )
+                                        )
                     continue
                 with open(destname, 'r', encoding='utf8') as expectfile:
                     chordproname = "{}.source".format(base)

--- a/patacrep/songs/chordpro/test/test_parser.py
+++ b/patacrep/songs/chordpro/test/test_parser.py
@@ -18,51 +18,68 @@ LANGUAGES = {
 # Set to True if you want to create missing rendered files
 CREATE_MISSING_RENDERED_FILE = False
 
-class TestParsingRendering(unittest.TestCase):
+def load_tests(loader, tests, pattern):
+    """
+    Add all `*.source` files to the test suite.
+    """
+    del loader, tests, pattern
+    suite = unittest.TestSuite()
+    for source in sorted(glob.glob(os.path.join(
+            os.path.dirname(__file__),
+            '*.source',
+        ))):
+        single_test = TestSingleParsingRendering('run_test')
+        setattr(single_test, 'filename', source)
+        suite.addTest(single_test)
+    return suite
+
+class TestSingleParsingRendering(unittest.TestCase):
     """Test parsing and rendering"""
 
     maxDiff = None
 
-    def test_all(self):
-        """Test all `*.source` files.
+    def run_test(self):
+        """Test the self.filename (.source) file.
 
         For any given `foo.source`, it is parsed as a chordpro file, and
         should be rendered as `foo.sgc` with the chordpro renderer, and
         `foo.tex` with the latex renderer.
         """
+        if not hasattr(self, 'filename'):
+            return self.skipTest("No file to test")
+
+        source = getattr(self, 'filename')
         config = DEFAULT_CONFIG.copy()
         config.update({
             'encoding': 'utf8',
             })
-        for source in sorted(glob.glob(os.path.join(
-                os.path.dirname(__file__),
-                '*.source',
-            ))):
-            base = source[:-len(".source")]
-            for dest in LANGUAGES:
-                destname = "{}.{}".format(base, dest)
-                if not os.path.exists(destname):
-                    if CREATE_MISSING_RENDERED_FILE:
-                        print("Creating " + destname)
-                        with open(destname, 'w', encoding='utf8') as expectfile:
-                            chordproname = "{}.source".format(base)
-                            config['filename'] = chordproname
-                            expectfile.write(
-                                        ChordproSong(None, chordproname, config).render(
-                                            output=chordproname,
-                                            output_format=LANGUAGES[dest],
-                                            )
-                                        )
-                    continue
-                with open(destname, 'r', encoding='utf8') as expectfile:
-                    chordproname = "{}.source".format(base)
-                    config['filename'] = chordproname
-                    with disable_logging():
-                        with self.subTest(base=os.path.basename(base), format=dest):
-                            self.assertMultiLineEqual(
-                                ChordproSong(None, chordproname, config).render(
-                                    output=chordproname,
-                                    output_format=LANGUAGES[dest],
-                                    ).strip(),
-                                expectfile.read().strip(),
+        base = source[:-len(".source")]
+        for dest in LANGUAGES:
+            destname = "{}.{}".format(base, dest)
+            if not os.path.exists(destname):
+                if CREATE_MISSING_RENDERED_FILE:
+                    print("Creating " + destname)
+                    with open(destname, 'w', encoding='utf8') as expectfile:
+                        chordproname = "{}.source".format(base)
+                        config['filename'] = chordproname
+                        expectfile.write(
+                            ChordproSong(None, chordproname, config).render(
+                                output=chordproname,
+                                output_format=LANGUAGES[dest],
                                 )
+                            )
+                continue
+            with open(destname, 'r', encoding='utf8') as expectfile:
+                chordproname = "{}.source".format(base)
+                config['filename'] = chordproname
+                with disable_logging():
+                    with self.subTest(base=os.path.basename(base), format=dest):
+                        self.assertMultiLineEqual(
+                            ChordproSong(None, chordproname, config).render(
+                                output=chordproname,
+                                output_format=LANGUAGES[dest],
+                                ).strip(),
+                            expectfile.read().strip(),
+                            )
+
+


### PR DESCRIPTION
Deux propositions de changement pour les tests:

1. Ajout d'une variable `CREATE_MISSING_RENDERED_FILE` qu'il suffit de mettre à `True` pour générer les fichiers `.tex` et `.sgc` manquants (évite une écriture parfois fastidieuse, mais implique une vérification manuelle de la bonne génération)

2. création d'une fonction `load_tests` qui génère un test par fichier `.source`. Cela permet notamment de voir évoluer la validation des tests (au lieu que tout soit en un seul long test)