### PR TITLE
Added a command line tool to convert between file formats

### DIFF
--- a/patacrep/songs/chordpro/__init__.py
+++ b/patacrep/songs/chordpro/__init__.py
@@ -71,7 +71,7 @@ class ChordproSong(Song):
                 jinjaenv=jinjaenv,
                 ).template.render(context)
         except jinja2.exceptions.TemplateNotFound:
-            raise NotImplementedError()
+            raise NotImplementedError("Cannot convert to format '{}'.".format(output_format))
 
     @staticmethod
     @contextfunction

--- a/patacrep/songs/chordpro/__init__.py
+++ b/patacrep/songs/chordpro/__init__.py
@@ -1,8 +1,9 @@
 """Chordpro parser"""
 
 from jinja2 import Environment, FileSystemLoader, contextfunction
-import pkg_resources
+import jinja2
 import os
+import pkg_resources
 
 from patacrep import encoding, files
 from patacrep.songs import Song
@@ -63,11 +64,14 @@ class ChordproSong(Song):
         jinjaenv.filters['search_image'] = self.search_image
         jinjaenv.filters['search_partition'] = self.search_partition
 
-        return Renderer(
-            template=template,
-            encoding='utf8',
-            jinjaenv=jinjaenv,
-            ).template.render(context)
+        try:
+            return Renderer(
+                template=template,
+                encoding='utf8',
+                jinjaenv=jinjaenv,
+                ).template.render(context)
+        except jinja2.exceptions.TemplateNotFound:
+            raise NotImplementedError()
 
     @staticmethod
     @contextfunction

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     for file in song_files:
-        song = song_parsers[source](".", file, DEFAULT_CONFIG)
+        song = song_parsers[source]("", file, DEFAULT_CONFIG)
         try:
             converted = song.render(dest)
             destname = "{}.{}".format(".".join(file.split(".")[:-1]), dest)

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -58,9 +58,10 @@ if __name__ == "__main__":
         song = song_parsers[source]("", file, DEFAULT_CONFIG)
         try:
             destname = "{}.{}".format(".".join(file.split(".")[:-1]), dest)
-            if os.path.exists(destname) and not remember:
+            dest_exists = os.path.exists(destname)
+            if dest_exists and not remember:
                 overwrite, remember = confirm(destname)
-            if not overwrite:
+            if dest_exists and not overwrite:
                 continue
             converted = song.render(dest)
             with open(destname, "w") as destfile:

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -3,6 +3,7 @@
 See the :meth:`__usage` method for more information.
 """
 
+import os
 import logging
 import sys
 
@@ -12,17 +13,28 @@ from patacrep import files
 LOGGER = logging.getLogger(__name__)
 
 def __usage():
-    return "python3 -m patacrep.songs.convert chordpro latex FILE"
+    return "python3 -m patacrep.songs.convert INPUTFORMAT OUTPUTFORMAT FILES"
+
+def yesno(prompt):
+    while True:
+        answer = input("{} [yn] ".format(prompt))
+        if answer.strip().lower() == "y":
+            return True
+        if answer.strip().lower() == "n":
+            return False
+
+def confirm(destname):
+    return yesno("File '{}' already exist. Overwrite?".format(destname))
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
+    if len(sys.argv) < 4:
         LOGGER.error("Invalid number of arguments.")
         LOGGER.error("Usage: %s", __usage())
         sys.exit(1)
 
     source = sys.argv[1]
     dest = sys.argv[2]
-    file = sys.argv[3]
+    song_files = sys.argv[3:]
 
     song_parsers = files.load_plugins(
         datadirs=DEFAULT_CONFIG.get('datadir', []),
@@ -38,11 +50,23 @@ if __name__ == "__main__":
             )
         sys.exit(1)
 
-    song = song_parsers[source](".", file, DEFAULT_CONFIG)
-    try:
-        print(song.render(dest))
-    except NotImplementedError:
-        LOGGER.error("Cannot convert to format '%s'.", dest)
-        sys.exit(1)
+    for file in song_files:
+        song = song_parsers[source](".", file, DEFAULT_CONFIG)
+        try:
+            converted = song.render(dest)
+            destname = "{}.{}".format(".".join(file.split(".")[:-1]), dest)
+            if os.path.exists(destname):
+                if not confirm(destname):
+                    continue
+            with open(destname, "w") as destfile:
+                destfile.write(converted)
+
+        except NotImplementedError:
+            LOGGER.error("Cannot convert to format '%s'.", dest)
+            sys.exit(1)
+        except KeyboardInterrupt:
+            print()
+            LOGGER.info("Aborted by user.")
+            sys.exit(0)
 
     sys.exit(0)

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -1,0 +1,48 @@
+"""Conversion between formats
+
+See the :meth:`__usage` method for more information.
+"""
+
+import logging
+import sys
+
+from patacrep.build import DEFAULT_CONFIG
+from patacrep import files
+
+LOGGER = logging.getLogger(__name__)
+
+def __usage():
+    return "python3 -m patacrep.songs.convert chordpro latex FILE"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        LOGGER.error("Invalid number of arguments.")
+        LOGGER.error("Usage: %s", __usage())
+        sys.exit(1)
+
+    source = sys.argv[1]
+    dest = sys.argv[2]
+    file = sys.argv[3]
+
+    song_parsers = files.load_plugins(
+        datadirs=DEFAULT_CONFIG.get('datadir', []),
+        root_modules=['songs'],
+        keyword='SONG_PARSERS',
+        )
+
+    if source not in song_parsers:
+        LOGGER.error(
+            "Unknown file format '%s'. Available ones are %s.",
+            source,
+            ", ".join(["'{}'".format(key) for key in song_parsers.keys()])
+            )
+        sys.exit(1)
+
+    song = song_parsers[source](".", file, DEFAULT_CONFIG)
+    try:
+        print(song.render(dest))
+    except NotImplementedError:
+        LOGGER.error("Cannot convert to format '%s'.", dest)
+        sys.exit(1)
+
+    sys.exit(0)

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -17,11 +17,14 @@ def __usage():
 
 def yesno(prompt):
     while True:
-        answer = input("{} [yn] ".format(prompt))
-        if answer.strip().lower() == "y":
-            return True
-        if answer.strip().lower() == "n":
-            return False
+        answer = input("{} [yn](folllow with * to remember) ".format(prompt)).strip().lower()
+        remember = (answer[-1] == "*")
+        if remember:
+            answer = answer[0:-1]
+        if answer == "y":
+            return True, remember
+        if answer == "n":
+            return False, remember
 
 def confirm(destname):
     return yesno("File '{}' already exist. Overwrite?".format(destname))
@@ -50,14 +53,16 @@ if __name__ == "__main__":
             )
         sys.exit(1)
 
+    remember = False
     for file in song_files:
         song = song_parsers[source]("", file, DEFAULT_CONFIG)
         try:
             converted = song.render(dest)
             destname = "{}.{}".format(".".join(file.split(".")[:-1]), dest)
-            if os.path.exists(destname):
-                if not confirm(destname):
-                    continue
+            if os.path.exists(destname) and not remember:
+                overwrite, remember = confirm(destname)
+            if not overwrite:
+                continue
             with open(destname, "w") as destfile:
                 destfile.write(converted)
 

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -17,7 +17,7 @@ def __usage():
 
 def yesno(prompt):
     while True:
-        answer = input("{} [yn](folllow with * to remember) ".format(prompt)).strip().lower()
+        answer = input("{} [yn](append * to remember) ".format(prompt)).strip().lower()
         remember = (answer[-1] == "*")
         if remember:
             answer = answer[0:-1]

--- a/patacrep/songs/convert/__main__.py
+++ b/patacrep/songs/convert/__main__.py
@@ -57,12 +57,12 @@ if __name__ == "__main__":
     for file in song_files:
         song = song_parsers[source]("", file, DEFAULT_CONFIG)
         try:
-            converted = song.render(dest)
             destname = "{}.{}".format(".".join(file.split(".")[:-1]), dest)
             if os.path.exists(destname) and not remember:
                 overwrite, remember = confirm(destname)
             if not overwrite:
                 continue
+            converted = song.render(dest)
             with open(destname, "w") as destfile:
                 destfile.write(converted)
 


### PR DESCRIPTION
Usage example : 

~~~shell
$ python -m patacrep.songs.convert sgc html metadata.source
    <h1 class="song-title">Title</h1>
    <h2 class="song-title">Subtitle1</h2>
    <h2 class="song-title">Subtitle2</h2>
    <h2 class="song-title">Subtitle3</h2>
    <h2 class="song-title">Subtitle4</h2>
    <h2 class="song-title">Subtitle5</h2>
<h2 class="song-artist"> Author1</h2>
<h2 class="song-artist"> Author2</h2>
<span class="song-album">Album: Album</span><br/>
<span class="song-copyright">Copyright: Copyright</span><br/>
<span class="song-capo">Capo: Capo</span><br/>

<span class="song-language">Language: french</span><br>

<img src="Cover"><br>
{key: foo: Foo}


<div class="song_content">
<div class="comment">Comment</div>
<div class="guitar_comment">GuitarComment</div>
<img src="Image">
<a class="song-partition" href="Lilypond">Lilypond</a>
</div>
~~~