### PR TITLE
Only one language per song (the latest defined)

### DIFF
--- a/examples/example-all.sb
+++ b/examples/example-all.sb
@@ -6,6 +6,7 @@
     "pictures"
   ],
 "booktype" : "chorded",
+"datadir": ["datadir2"],
 "template" : "patacrep.tex",
 "lang" : "french",
 "encoding": "utf8",

--- a/patacrep/content/song.py
+++ b/patacrep/content/song.py
@@ -92,7 +92,7 @@ def parse(keyword, argument, contentlist, config):
                         config,
                         ))
                     songlist.append(renderer)
-                    config["_languages"].update(renderer.song.language)
+                    config["_languages"].add(renderer.song.language)
             if len(songlist) > before:
                 break
         if len(songlist) == before:

--- a/patacrep/content/song.py
+++ b/patacrep/content/song.py
@@ -92,7 +92,7 @@ def parse(keyword, argument, contentlist, config):
                         config,
                         ))
                     songlist.append(renderer)
-                    config["_languages"].update(renderer.song.languages)
+                    config["_languages"].update(renderer.song.language)
             if len(songlist) > before:
                 break
         if len(songlist) == before:

--- a/patacrep/latex/ast.py
+++ b/patacrep/latex/ast.py
@@ -46,7 +46,7 @@ class Command(AST):
         self.optional = optional
 
         if name == r'\selectlanguage':
-            self.metadata['@language'] = self.mandatory
+            self.metadata['@language'] = self.mandatory[0]
 
     def __str__(self):
         if self.name in [r'\emph']:

--- a/patacrep/latex/ast.py
+++ b/patacrep/latex/ast.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=too-few-public-methods
 
+DEFAULT_LANGUAGE = "english"
+
 class AST:
     """Base class for the tree."""
     # pylint: disable=no-init
@@ -16,7 +18,7 @@ class AST:
         parsing.
         """
         cls.metadata = {
-            '@languages': set(),
+            '@language': DEFAULT_LANGUAGE,
             }
 
 class Expression(AST):
@@ -44,7 +46,7 @@ class Command(AST):
         self.optional = optional
 
         if name == r'\selectlanguage':
-            self.metadata['@languages'] |= set(self.mandatory)
+            self.metadata['@language'] = self.mandatory
 
     def __str__(self):
         if self.name in [r'\emph']:

--- a/patacrep/songs/__init__.py
+++ b/patacrep/songs/__init__.py
@@ -89,7 +89,7 @@ class Song:
         "cached",
         "data",
         "subpath",
-        "languages",
+        "language",
         "authors",
         "_filehash",
         "_version",
@@ -184,8 +184,8 @@ class Song:
 
         - titles: the list of (raw) titles. This list will be processed to
           remove prefixes.
-        - languages: the list of languages used in the song, as languages
-          recognized by the LaTeX babel package.
+        - language: the main language of the song, as language recognized by
+          the LaTeX babel package.
         - authors: the list of (raw) authors. This list will be processed to
           'clean' it (see function :func:`patacrep.authors.processauthors`).
         - data: song metadata. Used (among others) to sort the songs.

--- a/patacrep/songs/chordpro/__init__.py
+++ b/patacrep/songs/chordpro/__init__.py
@@ -38,7 +38,7 @@ class ChordproSong(Song):
             song = parse_song(song.read(), self.fullpath)
         self.authors = song.authors
         self.titles = song.titles
-        self.languages = song.get_data_argument('language', [self.config['lang']])
+        self.language = song.get_data_argument('language', self.config['lang'])
         self.data = song.meta
         self.cached = {
             'song': song,
@@ -49,7 +49,7 @@ class ChordproSong(Song):
             templatedirs = []
 
         context = {
-            'language': self.languages[0],
+            'language': self.language,
             "titles": self.titles,
             "authors": self.authors,
             "metadata": self.data,

--- a/patacrep/songs/chordpro/ast.py
+++ b/patacrep/songs/chordpro/ast.py
@@ -193,7 +193,6 @@ class Song(AST):
         "artist": "add_author",
         "key": "add_key",
         "define": "add_cumulative",
-        "language": "add_cumulative",
         }
 
     def __init__(self, filename):

--- a/patacrep/songs/latex/__init__.py
+++ b/patacrep/songs/latex/__init__.py
@@ -20,8 +20,8 @@ class LatexSong(Song):
             self.data = parse_song(song.read(), self.fullpath)
         self.titles = self.data['@titles']
         del self.data['@titles']
-        self.languages = self.data['@languages']
-        del self.data['@languages']
+        self.language = self.data['@language']
+        del self.data['@language']
         if "by" in self.data:
             self.authors = [self.data['by']]
             del self.data['by']

--- a/test/test_chordpro/metadata.source
+++ b/test/test_chordpro/metadata.source
@@ -4,8 +4,8 @@
 {subtitle: Subtitle4}
 {t: Subtitle2}
 {st: Subtitle5}
-{language: french}
 {language: english}
+{language: french}
 {by: Author1}
 {artist: Author2}
 {album: Album}


### PR DESCRIPTION
Première étape de #95 

Pour simplifier un peu la gestion des langues, je propose qu'on autorise seulement une langue par chant (la langue principalement utilisée).

Au niveau de Chordpro, j'ai pas eu trop de mal à le modifier, en revanche cela ne fonctionne pas pour LaTeX (donc la compilation échoue).
Je ne sais pas trop quel est le problème...est-ce que quelqu'un ( @paternal par exemple ;-) pourrait m'aider ?