### PR TITLE
Bug in tests when accentuated chars are used

### DIFF
--- a/test/test_chordpro/metadata.sgc
+++ b/test/test_chordpro/metadata.sgc
@@ -7,7 +7,7 @@
 {title: Subtitle4}
 {title: Subtitle5}
 {artist:  Author1}
-{artist:  Texte de Jean Richepin, chanté par Georges Brassens}
+{artist: Texte de Jean Richepin, chanté par Georges Brassens}
 {album: Album}
 {copyright: Copyright}
 {cov: metadata_cover}

--- a/test/test_chordpro/metadata.sgc
+++ b/test/test_chordpro/metadata.sgc
@@ -1,13 +1,13 @@
 {lang: fr}
 {capo: Capo}
-{title: Title}
+{title: Je t'ai Manqué}
 {title: Subtitle1}
 {title: Subtitle2}
 {title: Subtitle3}
 {title: Subtitle4}
 {title: Subtitle5}
 {artist:  Author1}
-{artist:  Author2}
+{artist:  Texte de Jean Richepin, chanté par Georges Brassens}
 {album: Album}
 {copyright: Copyright}
 {cov: metadata_cover}

--- a/test/test_chordpro/metadata.source
+++ b/test/test_chordpro/metadata.source
@@ -1,5 +1,5 @@
 {subtitle: Subtitle3}
-{title: Title}
+{title: Je t'ai Manqué}
 {title: Subtitle1}
 {subtitle: Subtitle4}
 {t: Subtitle2}
@@ -7,7 +7,7 @@
 {lang: en}
 {lang: fr}
 {by: Author1}
-{artist: Author2}
+{artist: Texte de Jean Richepin, chanté par Georges Brassens}
 {album: Album}
 {copyright: Copyright}
 {cover: metadata_cover}

--- a/test/test_chordpro/metadata.tex
+++ b/test/test_chordpro/metadata.tex
@@ -8,7 +8,7 @@ Subtitle4\\
 Subtitle5}[
   by={
          Author1,
-         Texte de Jean Richepin, chanté par Georges Brassens  },
+        Texte de Jean Richepin, chanté par Georges Brassens  },
   album={Album},
   copyright={Copyright},
     cov={img/test/test_chordpro/metadata_cover},

--- a/test/test_chordpro/metadata.tex
+++ b/test/test_chordpro/metadata.tex
@@ -1,6 +1,6 @@
 \selectlanguage{french}
 
-\beginsong{Title\\
+\beginsong{Je t'ai Manqué\\
 Subtitle1\\
 Subtitle2\\
 Subtitle3\\
@@ -8,7 +8,7 @@ Subtitle4\\
 Subtitle5}[
   by={
          Author1,
-         Author2  },
+         Texte de Jean Richepin, chanté par Georges Brassens  },
   album={Album},
   copyright={Copyright},
     cov={img/test/test_chordpro/metadata_cover},

--- a/test/test_chordpro/test_parser.py
+++ b/test/test_chordpro/test_parser.py
@@ -9,6 +9,7 @@ from pkg_resources import resource_filename
 
 from patacrep import files
 from patacrep.build import DEFAULT_CONFIG
+from patacrep.encoding import open_read
 
 from .. import disable_logging
 
@@ -63,7 +64,7 @@ class FileTestMeta(type):
             if base is None or dest is None:
                 return
             destname = "{}.{}".format(base, dest)
-            with open(destname, 'r', encoding='utf8') as expectfile:
+            with open_read(destname) as expectfile:
                 chordproname = "{}.source".format(base)
                 with disable_logging():
                     self.assertMultiLineEqual(


### PR DESCRIPTION
En rajoutant des accents dans les tests, cela provoque un échec des tests, dû à une erreur d'encodage:
```
- \beginsong{Je t'ai ManquĂŠ\\
?                         ^^
+ \beginsong{Je t'ai Manqué\\
```