### PR TITLE
Travis should skip only the full compilation

### DIFF
--- a/test/test_compilation/datadir.tex.control
+++ b/test/test_compilation/datadir.tex.control
@@ -33,7 +33,6 @@ guitar,
 
 
 \PassOptionsToPackage{english}{babel}
-\PassOptionsToPackage{english}{babel}
 \usepackage[english]{babel}
 \lang{english}
 

--- a/test/test_compilation/test_compilation.py
+++ b/test/test_compilation/test_compilation.py
@@ -84,7 +84,7 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
                         )
 
             # Check compilation
-            if not 'TRAVIS' in os.environ:
+            if 'TRAVIS' not in os.environ:
                 # Travis does not support lualatex compilation yet
                 self.assertEqual(0, self.compile_songbook(songbook))
 

--- a/test/test_compilation/test_compilation.py
+++ b/test/test_compilation/test_compilation.py
@@ -48,8 +48,6 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
     def _create_test(cls, base):
         """Return a function testing that `base` compiles."""
 
-        @unittest.skipIf('TRAVIS' in os.environ,
-                         "Travis does not support lualatex compilation yet")
         def test_compile(self):
             """Test that `base` is correctly compiled."""
             if base is None:
@@ -86,7 +84,9 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
                         )
 
             # Check compilation
-            self.assertEqual(0, self.compile_songbook(songbook))
+            if not 'TRAVIS' in os.environ:
+                # Travis does not support lualatex compilation yet
+                self.assertEqual(0, self.compile_songbook(songbook))
 
         test_compile.__doc__ = (
             "Test that '{base}' is correctly compiled."


### PR DESCRIPTION
Travis doit quand même tester la génération du fichier `.tex`.

Il serait peut-ête plus propre de séparer "vérification du .tex" et "compilation complète", mais `_create_test` ne permet de retourner qu'un test: il faudrait donc créer une deuxième classe...