### PR TITLE
Test for lilypond compiler before starting compilation

### DIFF
--- a/patacrep/build.py
+++ b/patacrep/build.py
@@ -124,6 +124,7 @@ class Songbook(object):
         renderer.render_tex(output, config)
 
     def requires_lilypond(self):
+        """Tell if lilypond is part of the bookoptions"""
         return 'lilypond' in self.config.get('bookoptions', [])
 
 def _log_pipe(pipe):

--- a/patacrep/build.py
+++ b/patacrep/build.py
@@ -228,7 +228,7 @@ class SongbookBuilder(object):
                 stderr=PIPE,
                 universal_newlines=True,
                 )
-        except Exception as error:
+        except FileNotFoundError as error:
             raise errors.ExecutableNotFound(compiler)
 
         # Test if lilypond compiler is accessible
@@ -242,7 +242,7 @@ class SongbookBuilder(object):
                     stderr=PIPE,
                     universal_newlines=True,
                     )
-            except Exception as error:
+            except FileNotFoundError as error:
                 raise errors.ExecutableNotFound(lilypond_compiler)
 
         # Perform compilation

--- a/patacrep/build.py
+++ b/patacrep/build.py
@@ -123,6 +123,9 @@ class Songbook(object):
 
         renderer.render_tex(output, config)
 
+    def requires_lilypond(self):
+        return 'lilypond' in self.config.get('bookoptions', [])
+
 def _log_pipe(pipe):
     """Log content from `pipe`."""
     while 1:
@@ -226,6 +229,20 @@ class SongbookBuilder(object):
                 )
         except Exception as error:
             raise errors.ExecutableNotFound(compiler)
+
+        # Test if lilypond compiler is accessible
+        lilypond_compiler = 'lilypond'
+        if self.songbook.requires_lilypond():
+            try:
+                check_call(
+                    [lilypond_compiler, "--version"],
+                    stdin=PIPE,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    universal_newlines=True,
+                    )
+            except Exception as error:
+                raise errors.ExecutableNotFound(lilypond_compiler)
 
         # Perform compilation
         try:

--- a/patacrep/build.py
+++ b/patacrep/build.py
@@ -232,8 +232,8 @@ class SongbookBuilder(object):
             raise errors.ExecutableNotFound(compiler)
 
         # Test if lilypond compiler is accessible
-        lilypond_compiler = 'lilypond'
         if self.songbook.requires_lilypond():
+            lilypond_compiler = 'lilypond'
             try:
                 check_call(
                     [lilypond_compiler, "--version"],


### PR DESCRIPTION
Plutôt que de laisser LaTeX découvrir que lilypond n'existe pas, voici une PR pour les tester dans Python (et lever une exception appropriée).

Si l'on souhaite, on pourrait aussi désactiver lilypond et poursuivre tout de même la compilation (mais l'état actuel me convient)