### PR TITLE
Support of echo with chords inside

### DIFF
--- a/patacrep/data/templates/songs/chordpro/chordpro/content_echo
+++ b/patacrep/data/templates/songs/chordpro/chordpro/content_echo
@@ -1,0 +1,3 @@
+{start_(( content.type ))}
+  ((- render(content.line) -))
+{end_(( content.type ))}

--- a/patacrep/data/templates/songs/chordpro/latex/content_echo
+++ b/patacrep/data/templates/songs/chordpro/latex/content_echo
@@ -1,0 +1,3 @@
+\echo{
+  ((- render(content.line) -))
+}

--- a/patacrep/songs/chordpro/ast.py
+++ b/patacrep/songs/chordpro/ast.py
@@ -122,6 +122,15 @@ class Line(AST):
         """Return `True` iff line is empty."""
         return len(self.strip().line) == 0
 
+class Echo(AST):
+    """An inline echo"""
+    _template = "echo"
+    type = 'echo'
+
+    def __init__(self, line):
+        super().__init__()
+        self.line = line
+
 class LineElement(AST):
     """Something present on a line."""
     # pylint: disable=abstract-method

--- a/patacrep/songs/chordpro/lexer.py
+++ b/patacrep/songs/chordpro/lexer.py
@@ -26,6 +26,8 @@ tokens = (
     'EOB',
     'SOT',
     'EOT',
+    'SE',
+    'EE',
 )
 
 class ChordProLexer:
@@ -67,6 +69,16 @@ class ChordProLexer:
     @staticmethod
     def t_EOB(token):
         r'{(eob|end_of_bridge)}'
+        return token
+
+    @staticmethod
+    def t_SE(token):
+        r'{(se|start_echo)}'
+        return token
+
+    @staticmethod
+    def t_EE(token):
+        r'{(ee|end_echo)}'
         return token
 
     def t_SOT(self, token):

--- a/patacrep/songs/chordpro/syntax.py
+++ b/patacrep/songs/chordpro/syntax.py
@@ -208,6 +208,7 @@ class ChordproParser(Parser):
     def p_line(symbols):
         """line : word line_next
                 | chord line_next
+                | echo line_next
                 | directive maybespace
         """
         if isinstance(symbols[2], ast.Line):
@@ -227,6 +228,7 @@ class ChordproParser(Parser):
         """line_next : word line_next
                      | space line_next
                      | chord line_next
+                     | echo line_next
                      | empty
         """
         if len(symbols) == 2:
@@ -289,6 +291,11 @@ class ChordproParser(Parser):
         else:
             symbols[0] = symbols[3].prepend(symbols[1])
 
+    @staticmethod
+    def p_echo(symbols):
+        """echo : SE line_next EE
+        """
+        symbols[0] = ast.Echo(symbols[2])
 
     @staticmethod
     def p_tab(symbols):

--- a/test/test_song/echo.csg
+++ b/test/test_song/echo.csg
@@ -1,0 +1,29 @@
+{lang: en}
+
+Soon an echo {start_echo}with chords: [C]cool [A]isn't it?{end_echo}
+
+
+Second example {start_echo} surrounded with spaces {end_echo} continuing
+
+
+Third example {start_echo} on{end_echo}
+{start_echo}multiple lines ! {end_echo} continuing
+
+
+{start_echo}Fourth example starting line {end_echo} continuing
+
+
+Fifth example at the {start_echo}end{end_echo}
+
+
+{start_echo}Sixth example: only me!{end_echo}
+
+
+{start_of_chorus}
+    {start_echo}Seventh example in a chorus{end_echo}
+{end_of_chorus}
+
+
+{start_of_bridge}
+    And in a {start_echo}bridge{end_echo}
+{end_of_bridge}

--- a/test/test_song/echo.csg.source
+++ b/test/test_song/echo.csg.source
@@ -1,0 +1,20 @@
+Soon an echo {start_echo}with chords: [C]cool [A]isn't it?{end_echo}
+
+Second example {start_echo} surrounded with spaces {end_echo} continuing
+
+Third example {start_echo} on{end_echo}
+{start_echo}multiple lines ! {end_echo} continuing
+
+{start_echo}Fourth example starting line {end_echo} continuing
+
+Fifth example at the {start_echo}end{end_echo}
+
+{start_echo}Sixth example: only me!{end_echo}
+
+{soc}
+{start_echo}Seventh example in a chorus{end_echo}
+{eoc}
+
+{sob}
+And in a {start_echo}bridge{end_echo}
+{eob}

--- a/test/test_song/echo.tsg
+++ b/test/test_song/echo.tsg
@@ -1,0 +1,49 @@
+\selectlanguage{english}
+
+\beginsong{}[
+  by={
+  },
+]
+
+
+\begin{verse}
+    Soon an echo \echo{with chords: \[C]cool \[A]isn't it?}
+\end{verse}
+
+
+\begin{verse}
+    Second example \echo{ surrounded with spaces } continuing
+\end{verse}
+
+
+\begin{verse}
+    Third example \echo{ on}
+    \echo{multiple lines ! } continuing
+\end{verse}
+
+
+\begin{verse}
+    \echo{Fourth example starting line } continuing
+\end{verse}
+
+
+\begin{verse}
+    Fifth example at the \echo{end}
+\end{verse}
+
+
+\begin{verse}
+    \echo{Sixth example: only me!}
+\end{verse}
+
+
+\begin{chorus}
+    \echo{Seventh example in a chorus}
+\end{chorus}
+
+
+\begin{bridge}
+    And in a \echo{bridge}
+\end{bridge}
+
+\endsong


### PR DESCRIPTION
Je risque d'avoir besoin d'un support de `\echo{}` dans des fichiers chordpro pour un projet perso, voici donc une PR pour proposer une implémentation.

Il faut notamment permettre les accords au sein de ces `echo`.

Je propose la paire `{start_echo}`, `{end_echo}` sans le `of`, car ce ne sont pas des paragraphes (comme `chorus` / `bridge`).

Qu'en pensez-vous ?
Est-ce que la syntaxe vous convient ? Est-ce que l'implémentation semble correcte ?