### PR TITLE
`cd` evolution (content plugin)

### DIFF
--- a/patacrep/content/__init__.py
+++ b/patacrep/content/__init__.py
@@ -21,7 +21,7 @@ met, the corresponding parser is called.
 
     - sort
     - section*
-    - cwd
+    - cd
 
 # Parsers
 

--- a/patacrep/content/addpath.py
+++ b/patacrep/content/addpath.py
@@ -1,36 +1,40 @@
-"""Change base directory before importing songs."""
+"""Add a path directory to the 'songdir' list."""
 
 from patacrep.content import process_content, validate_parser_argument
+from patacrep.songs import DataSubpath
 
 #pylint: disable=unused-argument
 @validate_parser_argument("""
 type: //rec
-required:
-  path: //str
 optional:
   content: //any
+required:
+  path: //str
 """)
 def parse(keyword, config, argument):
-    """Return a list of songs, whith a different base path.
+    """Return a list of songs, whith an another base path.
 
     Arguments:
     - keyword: unused;
     - config: the current songbook configuration dictionary;
     - argument: a dict containing:
-        path: string specifying the path to append to current songdirs;
+        path: string specifying the path to add to the songdirs list;
         content: songbook content, that is parsed by
             patacrep.content.process_content().
 
-    The 'path' is added as a relative path to every path already present
-    in config['songdir'] (which are 'songs' dir inside the datadirs).
+    This function adds 'path' to the directories where songs are searched
+    for, and then processes the content.
+
+    The 'path' is added as a relative path to the dir of the songbook file.
     """
     subpath = argument['path']
     old_songdir = config['_songdir']
 
-    config['_songdir'] = [path.clone().join(subpath) for path in config['_songdir']]
+    config['_songdir'] = [DataSubpath(config['_songbookfile_dir'], subpath)]
+    config['_songdir'].extend(old_songdir)
 
     processed_content = process_content(argument.get('content'), config)
     config['_songdir'] = old_songdir
     return processed_content
 
-CONTENT_PLUGINS = {'cd': parse}
+CONTENT_PLUGINS = {'addpath': parse}

--- a/patacrep/content/addsongdir.py
+++ b/patacrep/content/addsongdir.py
@@ -37,4 +37,4 @@ def parse(keyword, config, argument):
     config['_songdir'] = old_songdir
     return processed_content
 
-CONTENT_PLUGINS = {'addpath': parse}
+CONTENT_PLUGINS = {'addsongdir': parse}

--- a/patacrep/content/cd.py
+++ b/patacrep/content/cd.py
@@ -10,6 +10,7 @@ required:
   path: //str
 optional:
   content: //any
+  yaml_as_root: //bool
 """)
 def parse(keyword, config, argument):
     """Return a list songs, whith a different base path.
@@ -19,19 +20,27 @@ def parse(keyword, config, argument):
     - config: the current songbook configuration dictionary;
     - argument: a dict containing:
         path: string specifying the path to use as root;
+        yaml_as_root: (optional) if the yaml file folder should
+            be used as root folder
         content: songbook content, that is parsed by
             patacrep.content.process_content().
 
     This function adds 'path' to the directories where songs are searched
     for, and then processes the content.
 
-    The 'path' is added as a relative path to every path already present in
-      config['songdir'] (which are 'songs' dir inside the datadirs).
+    If 'yaml_as_root' is not set the 'path' is added as a relative path to
+    every path already present in config['songdir'] (which are 'songs' dir
+     inside the datadirs).
+    Otherwise only the 'path' folder of the yaml file is insert as first
+    folder to search into.
     """
     subpath = argument['path']
     old_songdir = config['_songdir']
 
-    config['_songdir'] = [path.clone().join(subpath) for path in config['_songdir']]
+    if argument.get('yaml_as_root', False):
+        config['_songdir'].insert(0, DataSubpath(config['_songbookfile_dir'], subpath))
+    else:
+        config['_songdir'] = [path.clone().join(subpath) for path in config['_songdir']]
 
     processed_content = process_content(argument.get('content'), config)
     config['_songdir'] = old_songdir

--- a/patacrep/content/cd.py
+++ b/patacrep/content/cd.py
@@ -35,10 +35,11 @@ def parse(keyword, config, argument):
     folder to the `songdir` list.
     """
     subpath = argument['path']
-    old_songdir = list(config['_songdir']) # force list duplication
+    old_songdir = config['_songdir']
 
     if argument.get('yaml_as_root', False):
-        config['_songdir'].insert(0, DataSubpath(config['_songbookfile_dir'], subpath))
+        config['_songdir'] = [DataSubpath(config['_songbookfile_dir'], subpath)]
+        config['_songdir'].extend(old_songdir)
     else:
         config['_songdir'] = [path.clone().join(subpath) for path in config['_songdir']]
 

--- a/patacrep/content/cd.py
+++ b/patacrep/content/cd.py
@@ -25,20 +25,16 @@ def parse(keyword, config, argument):
     This function adds 'path' to the directories where songs are searched
     for, and then processes the content.
 
-    The 'path' is added:
-    - first as a relative path to the *.yaml file directory;
-    - then as a relative path to every path already present in
-      config['songdir'] (which are 'song' dir inside the datadirs).
+    The 'path' is added as a relative path to every path already present in
+      config['songdir'] (which are 'songs' dir inside the datadirs).
     """
     subpath = argument['path']
     old_songdir = config['_songdir']
 
     config['_songdir'] = [path.clone().join(subpath) for path in config['_songdir']]
-    if '_songbookfile_dir' in config:
-        config['_songdir'].insert(0, DataSubpath(config['_songbookfile_dir'], subpath))
 
     processed_content = process_content(argument.get('content'), config)
     config['_songdir'] = old_songdir
     return processed_content
 
-CONTENT_PLUGINS = {'cwd': parse}
+CONTENT_PLUGINS = {'cd': parse}

--- a/patacrep/content/cd.py
+++ b/patacrep/content/cd.py
@@ -31,11 +31,11 @@ def parse(keyword, config, argument):
     If 'yaml_as_root' is not set the 'path' is added as a relative path to
     every path already present in config['songdir'] (which are 'songs' dir
      inside the datadirs).
-    Otherwise only the 'path' folder of the yaml file is insert as first
-    folder to search into.
+    Otherwise only the 'path' folder of the yaml file is inserted as first
+    folder to the `songdir` list.
     """
     subpath = argument['path']
-    old_songdir = config['_songdir']
+    old_songdir = list(config['_songdir']) # force list duplication
 
     if argument.get('yaml_as_root', False):
         config['_songdir'].insert(0, DataSubpath(config['_songbookfile_dir'], subpath))

--- a/patacrep/content/include.py
+++ b/patacrep/content/include.py
@@ -14,18 +14,19 @@ from patacrep import encoding, errors, files
 
 LOGGER = logging.getLogger(__name__)
 
-def load_from_datadirs(path, datadirs):
-    """Load 'path' from one of the datadirs.
+def load_from_datadirs(filename, songdirs):
+    """Load 'filename' from one of the songdirs.
 
-    Raise an exception if it was found if none of the datadirs of 'config'.
+    Raise an exception if it was not found in any songdir.
     """
-    for filepath in files.iter_datadirs(datadirs, "songs", path):
-        if os.path.exists(filepath):
-            return filepath
+    for path in songdirs:
+        fullpath = os.path.join(path.fullpath, filename)
+        if os.path.exists(fullpath):
+            return fullpath
     # File not found
     raise ContentError(
         "include",
-        errors.notfound(path, list(files.iter_datadirs(datadirs)))
+        errors.notfound(filename, list(songdirs))
         )
 
 #pylint: disable=unused-argument
@@ -53,7 +54,7 @@ def parse(keyword, config, argument):
 
     for path in argument:
         try:
-            filepath = load_from_datadirs(path, config['_datadir'])
+            filepath = load_from_datadirs(path, config['_songdir'])
         except ContentError as error:
             new_contentlist.append_error(error)
             continue

--- a/patacrep/content/include.py
+++ b/patacrep/content/include.py
@@ -10,7 +10,7 @@ import logging
 import yaml
 
 from patacrep.content import process_content, ContentError, ContentList, validate_parser_argument
-from patacrep import encoding, errors, files
+from patacrep import encoding, errors
 
 LOGGER = logging.getLogger(__name__)
 

--- a/patacrep/content/tex.py
+++ b/patacrep/content/tex.py
@@ -45,7 +45,6 @@ def parse(keyword, argument, config):
     filelist = ContentList()
     basefolders = itertools.chain(
         (path.fullpath for path in config['_songdir']),
-        files.iter_datadirs(config['_datadir']),
         files.iter_datadirs(config['_datadir'], 'latex'),
         )
     for filename in argument:

--- a/test/test_content/cwd.source
+++ b/test/test_content/cwd.source
@@ -1,3 +1,3 @@
-- cwd:
+- cd:
     path: subdir
     content:

--- a/test/test_content/cwd_list.source
+++ b/test/test_content/cwd_list.source
@@ -1,4 +1,4 @@
-- cwd:
+- cd:
     path: subdir
     content:
         - "exsong.sg"

--- a/test/test_content/sort.source
+++ b/test/test_content/sort.source
@@ -1,5 +1,6 @@
 - cd:
-    path: "../../datadir_sort"
+    path: "datadir_sort"
+    yaml_as_root: yes
     content:
       - section:
           name: "Title"

--- a/test/test_content/sort.source
+++ b/test/test_content/sort.source
@@ -1,5 +1,5 @@
-- cwd:
-    path: "datadir_sort"
+- cd:
+    path: "../../datadir_sort"
     content:
       - section:
           name: "Title"

--- a/test/test_content/sort.source
+++ b/test/test_content/sort.source
@@ -1,4 +1,4 @@
-- addpath:
+- addsongdir:
     path: "datadir_sort"
     content:
       - section:

--- a/test/test_content/sort.source
+++ b/test/test_content/sort.source
@@ -1,6 +1,5 @@
-- cd:
+- addpath:
     path: "datadir_sort"
-    yaml_as_root: yes
     content:
       - section:
           name: "Title"

--- a/test/test_songbook/content.yaml
+++ b/test/test_songbook/content.yaml
@@ -13,7 +13,8 @@ content:
   - songsection: Test of song section
   - cd:
       # relative to yaml songfile
-      path: /content_datadir/content
+      path: content_datadir/content
+      yaml_as_root: yes
       content:
         - "song.csg"
         - "song.tsg"

--- a/test/test_songbook/content.yaml
+++ b/test/test_songbook/content.yaml
@@ -11,7 +11,7 @@ content:
   - section: Test of section
   - sort:
   - songsection: Test of song section
-  - addpath:
+  - addsongdir:
       # relative to yaml songfile
       path: content_datadir/content
       content:

--- a/test/test_songbook/content.yaml
+++ b/test/test_songbook/content.yaml
@@ -11,10 +11,9 @@ content:
   - section: Test of section
   - sort:
   - songsection: Test of song section
-  - cd:
+  - addpath:
       # relative to yaml songfile
       path: content_datadir/content
-      yaml_as_root: yes
       content:
         - "song.csg"
         - "song.tsg"

--- a/test/test_songbook/content.yaml
+++ b/test/test_songbook/content.yaml
@@ -11,14 +11,14 @@ content:
   - section: Test of section
   - sort:
   - songsection: Test of song section
-  - cwd:
+  - cd:
       # relative to yaml songfile
-      path: content_datadir/content
+      path: /content_datadir/content
       content:
         - "song.csg"
         - "song.tsg"
-  - cwd:
-      # relative to datadir
+  - cd:
+      # relative to datadir 'songs' dir
       path: ../content
       content:
         - tex: foo.tex

--- a/test/test_songbook/onthefly/content.onthefly.yaml
+++ b/test/test_songbook/onthefly/content.onthefly.yaml
@@ -11,8 +11,8 @@ content:
   - section: Test of section
   - sort:
   - songsection: Test of song section
-  - cwd:
-      # relative to datadir 'song' dir
+  - cd:
+      # relative to datadir 'songs' dir
       path: ../content
       content:
         - tex: foo.tex


### PR DESCRIPTION
Proposition de résolution de #204 

Finalement, plutôt que de supprimer irrémédiablement la possibilité de `cd` depuis l'endroit du fichier `yaml`, j'ai rajouté un argument (facultatif) à `cd` (très facile avec yaml):
```yaml
cd:
  path: chemin
  yaml_as_root: yes
  content: ...
```

Le nom est évidemment pas encore top (`yaml_as_root`: `yes`/`no`).

@paternal que penses-tu d'une telle solution "hybride".
Ou est-ce qu'il faudrait plutôt créer une autre option pour éviter le mélange des genre ? (avec toujours le problème de nommage ;-)