### PR TITLE
Numbering plugin

### DIFF
--- a/patacrep/content/setcounter.py
+++ b/patacrep/content/setcounter.py
@@ -1,0 +1,48 @@
+"""Allows to set an arbitrary value to any LaTeX counter (like `songnum`)."""
+
+from patacrep.content import ContentItem, ContentList, validate_parser_argument
+
+class CounterSetter(ContentItem):
+    """Set a counter."""
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def render(self, __context):
+        """Set the value of the counter."""
+        return r'\setcounter{{{}}}{{{}}}'.format(self.name, self.value)
+
+#pylint: disable=unused-argument
+@validate_parser_argument("""
+type: //any
+of:
+  - //nil
+  - //int
+  - type: //rec
+    optional:
+      name: //str
+      value: //int
+""")
+def parse(keyword, argument, config):
+    """Parse the counter setter.
+
+    Arguments:
+    - nothing
+        reset the "songnum" counter to 1
+    - an int
+        reset the "songnum" counter to this value
+    - a dict:
+        - name ("songnum"): the counter to set;
+        - value: value to set the counter to;
+    """
+    if argument is None:
+        argument = {}
+    if isinstance(argument, int):
+        argument = {'value': argument}
+    name = argument.get('name', 'songnum')
+    value = argument.get('value', 1)
+    return ContentList([CounterSetter(name, value)])
+
+CONTENT_PLUGINS = {'setcounter': parse}

--- a/patacrep/data/latex/patacrep.sty
+++ b/patacrep/data/latex/patacrep.sty
@@ -443,4 +443,21 @@
 \def\@void[#1]{}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Prevent numbering reset on new 'songs' environment
+\newcounter{tempsongnum}
+
+\let\oldsongs\songs
+\let\endoldsongs\endsongs
+
+\renewenvironment{songs}[1]{%
+    \setcounter{tempsongnum}{\thesongnum}%
+    \oldsongs{#1}%
+    \setcounter{songnum}{\thetempsongnum}%
+}{%
+    \endoldsongs\ignorespacesafterend%
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \endinput

--- a/patacrep/data/latex/songs.sty
+++ b/patacrep/data/latex/songs.sty
@@ -2957,7 +2957,7 @@
   \gdef\SB@indexlist{#1}%
   \SB@chkidxlst%
   \stepcounter{SB@songsnum}%
-  \setcounter{songnum}{1}%
+  %\setcounter{songnum}{1}%
   \let\SB@sgroup\@empty%
   \ifinner\else\ifdim\pagetotal>\z@%
     \null\nointerlineskip%

--- a/patacrep/data/latex/songs.sty
+++ b/patacrep/data/latex/songs.sty
@@ -2957,7 +2957,7 @@
   \gdef\SB@indexlist{#1}%
   \SB@chkidxlst%
   \stepcounter{SB@songsnum}%
-  %\setcounter{songnum}{1}%
+  \setcounter{songnum}{1}%
   \let\SB@sgroup\@empty%
   \ifinner\else\ifdim\pagetotal>\z@%
     \null\nointerlineskip%

--- a/test/test_content/setcounter.control
+++ b/test/test_content/setcounter.control
@@ -1,0 +1,4 @@
+- setcounter{songnum}{101}
+- setcounter{songnum}{1}
+- setcounter{songnum}{5}
+- setcounter{counter_name}{-1}

--- a/test/test_content/setcounter.source
+++ b/test/test_content/setcounter.source
@@ -1,0 +1,7 @@
+- setcounter: 
+    value: 101
+- setcounter: 
+- setcounter: 5 
+- setcounter: 
+    name: counter_name
+    value: -1

--- a/test/test_content/test_content.py
+++ b/test/test_content/test_content.py
@@ -10,7 +10,7 @@ import yaml
 from pkg_resources import resource_filename
 
 from patacrep import content, files
-from patacrep.content import song, section, songsection, tex
+from patacrep.content import song, section, setcounter, songsection, tex
 from patacrep.songbook import prepare_songbook
 
 from .. import logging_reduced
@@ -88,6 +88,9 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
 
         elif isinstance(elem, tex.LaTeX):
             return files.path2posix(elem.filename)
+
+        elif isinstance(elem, setcounter.CounterSetter):
+            return elem.render(None)[1:]
 
         else:
             raise Exception(elem)

--- a/test/test_content/test_content.py
+++ b/test/test_content/test_content.py
@@ -76,21 +76,21 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
     @classmethod
     def _clean_path(cls, elem):
         """Shorten the path relative to the `songs` directory"""
-        if isinstance(elem, song.SongRenderer):
+
+        latex_command_classes = (
+            section.Section,
+            songsection.SongSection,
+            setcounter.CounterSetter,
+            )
+        if isinstance(elem, latex_command_classes):
+            return elem.render(None)[1:]
+
+        elif isinstance(elem, song.SongRenderer):
             songpath = os.path.join(os.path.dirname(__file__), 'datadir', 'songs')
             return files.path2posix(files.relpath(elem.song.fullpath, songpath))
 
-        elif isinstance(elem, section.Section):
-            return elem.render(None)[1:]
-
-        elif isinstance(elem, songsection.SongSection):
-            return elem.render(None)[1:]
-
         elif isinstance(elem, tex.LaTeX):
             return files.path2posix(elem.filename)
-
-        elif isinstance(elem, setcounter.CounterSetter):
-            return elem.render(None)[1:]
 
         else:
             raise Exception(elem)

--- a/test/test_songbook/content.tex.control
+++ b/test/test_songbook/content.tex.control
@@ -122,6 +122,9 @@ guitar,
 
 \songsection{Test of song section}
 
+
+\setcounter{songnum}{101}
+
 \begin{songs}{titleidx,authidx}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% content_datadir/content/song.csg

--- a/test/test_songbook/content.yaml
+++ b/test/test_songbook/content.yaml
@@ -11,6 +11,7 @@ content:
   - section: Test of section
   - sort:
   - songsection: Test of song section
+  - setcounter: 101
   - cwd:
       # relative to yaml songfile
       path: content_datadir/content


### PR DESCRIPTION
Une des idées de #206.

Forcer un saut dans la numérotation des chants.

Il y a trois syntaxes acceptées:
* Rétablir le compteur à 1
```yaml
setcounter:
```

* Établir le compteur à une valeur souhaitée
```yaml
setcounter: 101
```

* Établir un compteur spécifique à une valeur donnée (seul `songnum` est supporté en vrai)
```yaml
setcounter: 
  name: songnum
  value: -1
```

**Cela fonctionne actuellement avec un *hack* dans le fichier songs.sty, car une nouvelle section réinitialise ce compteur...**

@Luthaf si tu à une meilleur idée, je suis preneur !