### PR TITLE
Diagram page option

### DIFF
--- a/patacrep/data/templates/songbook/default.tex
+++ b/patacrep/data/templates/songbook/default.tex
@@ -103,12 +103,11 @@ description:
 
 (* block chords *)
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 (* endblock *)
 

--- a/patacrep/data/templates/songbook_model.yml
+++ b/patacrep/data/templates/songbook_model.yml
@@ -27,7 +27,15 @@ schema:
       type: //rec
       required:
         show: //bool
-        diagrampage: //bool
+        diagrampage:
+          type: //any
+          of:
+            - type: //str
+              value: "none"
+            - type: //str
+              value: "important"
+            - type: //str
+              value: "all"
         repeatchords: //bool
         lilypond: //bool
         tablatures: //bool
@@ -97,7 +105,7 @@ default:
     chords:
       show: yes
       diagramreminder: important
-      diagrampage: yes
+      diagrampage: all
       repeatchords: yes
       lilypond: no
       tablatures: no

--- a/patacrep/data/templates/styles/chords.sty
+++ b/patacrep/data/templates/styles/chords.sty
@@ -24,7 +24,7 @@
      \raisebox{2em}{\chordname{##1}} %
      } %
   % Placing boxes
-  \ifimportantdiagramonly%
+  \ifdiagrampagereduced%
        \pl@cechord{#1}%
        \hspace{\stretch{1}}%
        \usebox{\@chordgroupbox@ii}%
@@ -75,7 +75,17 @@
 
 
 \newcommand{\chords}{
+  \ifdiagrampage
   \begin{songs}{}
+    %important diagrams are hidden by \chordtabs
+    \renewcommand{\gtab}{\@ifstar
+                        \gtab@Original%
+                        \gtab@Original%
+                        }
+    \renewcommand{\utab}{\@ifstar
+                        \utab@Original%
+                        \utab@Original%
+                        }
     %hide song number
     \definecolor{SongNumberBgColor}{HTML}{FFFFFF}
     \renewcommand{\snumbgcolor}{SongNumberBgColor}
@@ -391,5 +401,6 @@
     \fi
 
   \end{songs}
+  \fi
 }
 \endinput

--- a/patacrep/data/templates/styles/patacrep.sty
+++ b/patacrep/data/templates/styles/patacrep.sty
@@ -26,11 +26,11 @@
 \newif{\iflilypondauto}
 \DeclareOption{lilypond}{\lilypondautotrue\lilypondtrue}
 
-% diagram: display chord page before the songs
+% diagram: insert a page of diagrams before the songs
 \newif{\ifdiagrampage}
 \DeclareOption{diagrampage}{\diagrampagetrue}
 
-% diagram: display chord page before the songs
+% diagram: insert a page of the "important diagrams" before the songs
 \newif{\ifdiagrampagereduced}
 \DeclareOption{diagrampagereduced}{\diagrampagereducedtrue\diagrampagetrue}
 

--- a/patacrep/data/templates/styles/patacrep.sty
+++ b/patacrep/data/templates/styles/patacrep.sty
@@ -26,6 +26,14 @@
 \newif{\iflilypondauto}
 \DeclareOption{lilypond}{\lilypondautotrue\lilypondtrue}
 
+% diagram: display chord page before the songs
+\newif{\ifdiagrampage}
+\DeclareOption{diagrampage}{\diagrampagetrue}
+
+% diagram: display chord page before the songs
+\newif{\ifdiagrampagereduced}
+\DeclareOption{diagrampagereduced}{\diagrampagereducedtrue\diagrampagetrue}
+
 % diagram: display chord diagrams at the beginning
 \newif{\ifdiagram}
 \DeclareOption{diagram}{\diagramtrue}

--- a/patacrep/templates.py
+++ b/patacrep/templates.py
@@ -296,4 +296,9 @@ def iter_bookoptions(config):
         elif config['chords']['diagramreminder'] == "all":
             yield 'diagram'
 
+        if config['chords']['diagrampage'] == "important":
+            yield 'diagrampagereduced'
+        elif config['chords']['diagrampage'] == "all":
+            yield 'diagrampage'
+
         yield config['chords']['instrument']

--- a/test/test_songbook/content.tex.control
+++ b/test/test_songbook/content.tex.control
@@ -26,6 +26,7 @@
 chorded,
 pictures,
 diagram,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -79,13 +80,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/datadir.tex.control
+++ b/test/test_songbook/datadir.tex.control
@@ -28,6 +28,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -82,13 +83,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/lang_default.tex.control
+++ b/test/test_songbook/lang_default.tex.control
@@ -26,6 +26,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{crepbook}
 
@@ -113,13 +114,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/lang_en.tex.control
+++ b/test/test_songbook/lang_en.tex.control
@@ -26,6 +26,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{crepbook}
 
@@ -113,13 +114,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/lang_fr.tex.control
+++ b/test/test_songbook/lang_fr.tex.control
@@ -26,6 +26,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{crepbook}
 
@@ -113,13 +114,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/languages.tex.control
+++ b/test/test_songbook/languages.tex.control
@@ -27,6 +27,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -82,13 +83,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/onthefly/content.onthefly.tex.control
+++ b/test/test_songbook/onthefly/content.onthefly.tex.control
@@ -25,6 +25,7 @@
 chorded,
 pictures,
 diagram,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -77,13 +78,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/syntax.tex.control
+++ b/test/test_songbook/syntax.tex.control
@@ -27,6 +27,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -79,13 +80,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}

--- a/test/test_songbook/unicode.tex.control
+++ b/test/test_songbook/unicode.tex.control
@@ -27,6 +27,7 @@ chorded,
 pictures,
 repeatchords,
 importantdiagramonly,
+diagrampage,
 guitar,
     ]{patacrep}
 
@@ -79,13 +80,12 @@ guitar,
 \showindex{\authorindexname}{authidx}
 
 % list of chords
-\ifchorded
-  \ifdiagram
-     \phantomsection
-     \addcontentsline{toc}{section}{\chordlistname}
-     \chords
-  \fi
+\ifdiagrampage
+   \phantomsection
+   \addcontentsline{toc}{section}{\chordlistname}
+   \chords
 \fi
+\setcounter{songnum}{1}%
 
 \phantomsection
 \addcontentsline{toc}{section}{\songlistname}


### PR DESCRIPTION
Jusqu'à présent, les accords présentés sur la page dédiée étaient dépendants des options des diagrammes rappelés en début de chanson.

Cette PR à pour but de les rendre indépendants.

L'option `diagrampage` peut désormais prendre trois valeur (comme `diagramreminder`): 
```
- all
- important
- none
```

Au passage, cela corrige un bug de numérotation des chants (qui commençait à 0 si la page d'accords n'était pas incluse)