### PR TITLE
bug fix for empty keyword in index generation

### DIFF
--- a/patacrep/authors.py
+++ b/patacrep/authors.py
@@ -17,11 +17,11 @@ def compile_authwords(authwords):
         'ignore': authwords.get('ignore', []),
         'after': [
             re.compile(RE_AFTER.format(word))
-            for word in authwords.get('after')
+            for word in authwords.get('after', [])
             ],
         'separators': [
             re.compile(RE_SEPARATOR.format(word))
-            for word in ([" %s" % word for word in authwords['separators']] + [',', ';'])
+            for word in ([" %s" % word for word in authwords.get('separators', [])] + [',', ';'])
             ],
         }
 


### PR DESCRIPTION
Cette PR règle https://github.com/patacrep/patacrep/issues/215, 
selon la solution suggérée par @oliverpool.
J'ai vérifié que j'obtiens bien les indexs de chanson et d'auteurs. 

