### PR TITLE
Consider 'error' on contentlist exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * Bugfixes
   * The capo directive of the Chordpro files is now considered [#224](https://github.com/patacrep/patacrep/pull/224)
   * Chordpro files don't need to end with a trailing line [#223](https://github.com/patacrep/patacrep/pull/223)
+* Enhancements
+  * Error management
+    * The 'error' option is considered for contentlist errors (incorrect syntax for instance) [#226](https://github.com/patacrep/patacrep/pull/226)
 
 # patacrep 5.0.0
 

--- a/patacrep/content/__init__.py
+++ b/patacrep/content/__init__.py
@@ -185,6 +185,12 @@ class ContentList:
                 continue
             yield from item.iter_errors()
 
+    def has_errors(self):
+        """Return `True` iff errors has been found."""
+        for _ in self.iter_errors():
+            return True
+        return False
+
 class EmptyContentList(ContentList):
     """Empty content list: contain only errors."""
     def __init__(self, *, errors):
@@ -281,4 +287,6 @@ def process_content(content, config=None):
                     contentlist.append_error(error)
         else:
             contentlist.append_error(ContentError(str(elem), "Unknown content type."))
+    if contentlist.has_errors() and config['_error'] in ("failonsong", "failonbook"):
+        raise ContentError("Error while parsing the 'content' section of the songbook. Stopping as requested.")
     return contentlist

--- a/patacrep/content/__init__.py
+++ b/patacrep/content/__init__.py
@@ -288,5 +288,7 @@ def process_content(content, config=None):
         else:
             contentlist.append_error(ContentError(str(elem), "Unknown content type."))
     if contentlist.has_errors() and config['_error'] in ("failonsong", "failonbook"):
-        raise ContentError("Error while parsing the 'content' section of the songbook. Stopping as requested.")
+        raise ContentError(
+            "Error while parsing the 'content' section of the songbook. Stopping as requested."
+        )
     return contentlist

--- a/patacrep/data/templates/songbook_model.yml
+++ b/patacrep/data/templates/songbook_model.yml
@@ -99,6 +99,7 @@ schema:
             - type: //nil
 default:
   en:
+    _error: "fix"
     _datadir: [] # For test reasons
     book:
       lang: en


### PR DESCRIPTION
Si il y a un problème dans la syntaxe du fichier `.yaml` et que l'option `failonsong` (ou `failonbook`) est active, la compilation devrait s'arrêter.