### PR TITLE
Undefined control sequence \pdfobjcompresslevel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # patacrep {current_master}
 
+* Fix `pdfobjcompresslevel` undefined control sequence [#243](https://github.com/patacrep/patacrep/pull/243)
+
 # patacrep 5.1.1
 * Fix the auto-release to pypy
 

--- a/patacrep/data/templates/styles/patacrep.sty
+++ b/patacrep/data/templates/styles/patacrep.sty
@@ -79,11 +79,6 @@
     \renewcommand{\colbotglue}{0pt plus .5\textheight minus 0pt}%
 \fi
 
-% Patch for Debian TeXLive 2012
-% A bug may produce corrupted PDF
-\pdfobjcompresslevel=0
-
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Unicode characters
 \RequirePackage{fontspec}


### PR DESCRIPTION
Selon @cypriani : https://github.com/patacrep/patadata/issues/47

---

Désolé, encore des soucis de compilation. J'ai un patacrep à jour (version 5.1.1) installé via pip, comme il se doit. J'ai un patadata à jour (69f6d2c). J'ai un TexLive récent (paquet Debian version 2016.20160805-1). Toute tentative de compilation d'un carnet yaml (par exemple `songbook -v books/naheulbeuk.yaml`) échoue avec la même erreur :

```
DEBUG:patacrep.build:! Undefined control sequence.
DEBUG:patacrep.build:l.84 \pdfobjcompresslevel
```

Même chose si je tente de compiler directement le fichier .tex généré par songbook (par exemple `lualatex naheulbeuk.tex`. Le fichier incriminé est [`patacrep/data/templates/styles/patacrep.sty`](https://github.com/patacrep/patacrep/blob/master/patacrep/data/templates/styles/patacrep.sty#L84), ligne 84 donc :

```
% Patch for Debian TeXLive 2012
% A bug may produce corrupted PDF
\pdfobjcompresslevel=0
```

Commenter cette ligne permet apparemment de tout faire rentrer dans l'ordre, et je présume que le bug évoqué dans le commentaire a été corrigé depuis longtemps, mais je laisse à d'autre le soin d'en juger. L'idéal serait peut-être de faire un test sur la version du compilateur, pour rester compatible avec les vieilles Debian.

---