### PR TITLE
Add a way to display both guitar and ukulele diagrams

### DIFF
--- a/patacrep/data/templates/songbook_model.yml
+++ b/patacrep/data/templates/songbook_model.yml
@@ -55,6 +55,8 @@ schema:
               value: "guitar"
             - type: //str
               value: "ukulele"
+            - type: //str
+              value: "guitar+ukulele"
         notation:
             type: //any
             of:

--- a/patacrep/data/templates/styles/chords.sty
+++ b/patacrep/data/templates/styles/chords.sty
@@ -242,8 +242,8 @@
       \musicnote[french]{Accordage standard : {\nolyrics \[\printnoteE{} \printnoteA{} \printnoteD{} \printnoteG{} \printnoteB{} \printnoteE{}]}}
       \musicnote[english]{Standard tuning: {\nolyrics \[\printnoteE{} \printnoteA{} \printnoteD{} \printnoteG{} \printnoteB{} \printnoteE{}]}}
     \end{verse*}
-
     \endsong
+    \sclearpage
     \fi
 
     \ifukulele
@@ -398,6 +398,7 @@
     \end{verse*}
 
     \endsong
+    \sclearpage
     \fi
 
   \end{songs}

--- a/patacrep/templates.py
+++ b/patacrep/templates.py
@@ -325,4 +325,5 @@ def iter_bookoptions(config):
         elif config['chords']['diagrampage'] == "all":
             yield 'diagrampage'
 
-        yield config['chords']['instrument']
+        for instrument in config['chords']['instrument'].split("+"):
+            yield instrument


### PR DESCRIPTION
Voilà une première PR qui ne modifie que très peu le fonctionnement de patacrep.

Ce changement permet uniquement d'afficher les pages d'accords de la guitare et du ukulele toutes les deux sur le même document (avant il fallait choisir l'une ou l'autre).

La syntaxe choisie : `"guitar+ukulele"` l'est pour permettre éventuellement d'ajouter d'autres instruments tout en gardant la rétro compatibilité. Au début j'avais créé une liste d'argument qui se transformait tout seul en `list` mais ça cassait tous les autres carnets, l'avantage de passer par `split` c'est d'avoir également une `list` à la fin mais en partant tout de même d'une `string`