### PR TITLE
Fix yaml.load() calls

### DIFF
--- a/patacrep/build.py
+++ b/patacrep/build.py
@@ -380,6 +380,6 @@ def config_model(key):
     """
     model_path = pkg_datapath('templates', 'songbook_model.yml')
     with encoding.open_read(model_path) as model_file:
-        data = yaml.load(model_file)
+        data = yaml.safe_load(model_file)
 
     return data.get(key, {})

--- a/patacrep/content/__init__.py
+++ b/patacrep/content/__init__.py
@@ -238,7 +238,7 @@ def validate_parser_argument(raw_schema):
 
     Will raise `ContentError` if the schema is not respected.
     """
-    schema = Rx.make_schema(yaml.load(raw_schema))
+    schema = Rx.make_schema(yaml.safe_load(raw_schema))
 
     def wrap(parse):
         """Wrap the parse function"""

--- a/patacrep/content/include.py
+++ b/patacrep/content/include.py
@@ -74,7 +74,7 @@ def parse(keyword, config, argument):
                 filepath,
                 encoding=config['book']['encoding']
                 ) as content_file:
-                new_content = yaml.load(content_file)
+                new_content = yaml.safe_load(content_file)
         except Exception as error: # pylint: disable=broad-except
             new_contentlist.append_error(ContentError(
                 keyword="include",

--- a/patacrep/songbook/__init__.py
+++ b/patacrep/songbook/__init__.py
@@ -26,13 +26,13 @@ def open_songbook(filename):
 
     try:
         with patacrep.encoding.open_read(filename) as songbook_file:
-            user_songbook = yaml.load(songbook_file)
+            user_songbook = yaml.safe_load(songbook_file)
         if 'encoding' in user_songbook.get('book', []):
             with encoding.open_read(
                 filename,
                 encoding=user_songbook['book']['encoding']
                 ) as songbook_file:
-                user_songbook = yaml.load(songbook_file)
+                user_songbook = yaml.safe_load(songbook_file)
     except Exception as error: # pylint: disable=broad-except
         raise patacrep.errors.SongbookError(str(error))
 

--- a/patacrep/templates.py
+++ b/patacrep/templates.py
@@ -240,7 +240,7 @@ class TexBookRenderer(Renderer):
                 variables[templatename] = {}
             for variables_string in match:
                 try:
-                    variables[templatename].update(yaml.load(variables_string))
+                    variables[templatename].update(yaml.safe_load(variables_string))
                 except ValueError as exception:
                     raise errors.TemplateError(
                         exception,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(exclude=["test*"]),
     license="GPLv2 or any later version",
     install_requires=[
-        "argdispatch", "unidecode", "jinja2", "ply", "pyyaml",
+        "argdispatch", "unidecode", "jinja2", "ply", "pyyaml==5.4.1",
         ],
     entry_points={
         'console_scripts': [

--- a/test/test_book/test_compilation.py
+++ b/test/test_book/test_compilation.py
@@ -166,7 +166,7 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
         """Compile songbook "on the fly": without a physical songbook file."""
 
         with open(base + ".yaml", mode="r", encoding="utf8") as sbfile:
-            sbyaml = yaml.load(sbfile)
+            sbyaml = yaml.safe_load(sbfile)
 
         outputdir = os.path.dirname(base)
         outputname = os.path.basename(base)

--- a/test/test_content/test_content.py
+++ b/test/test_content/test_content.py
@@ -47,7 +47,7 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
             """Test that `base.source` produces the correct file list"""
             sourcename = "{}.source".format(base)
             with open(sourcename, mode="r", encoding="utf8") as sourcefile:
-                sbcontent = yaml.load(sourcefile)
+                sbcontent = yaml.safe_load(sourcefile)
 
             outputdir = os.path.dirname(base)
             config = cls._generate_config(sbcontent, outputdir, base)
@@ -60,7 +60,7 @@ class FileTest(unittest.TestCase, metaclass=dynamic.DynamicTest):
             if not os.path.exists(controlname):
                 raise Exception("Missing control:" + str(controlname).replace("'", '"'))
             with open(controlname, mode="r", encoding="utf8") as controlfile:
-                controllist = yaml.load(controlfile)
+                controllist = yaml.safe_load(controlfile)
 
             self.assertEqual(controllist, sourcelist)
 


### PR DESCRIPTION
Before PyYaml < 6, the following warning is issued:

    ./patacrep/patacrep/songbook/__init__.py:29:
    YAMLLoadWarning: calling yaml.load() without Loader=... is
    deprecated, as the default Loader is unsafe. Please read
    https://msg.pyyaml.org/load for full details.

With PyYaml >= 6, the program crashes.